### PR TITLE
並列で複数件画像をフェッチできるようクライアントを修正

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,6 +62,7 @@ app.use(function(req, res, next) {
 if (app.get('env') === 'development') {
     app.use(function(err, req, res, next) {
         res.status(err.status || 500);
+        console.log(err);
         res.render('error', {
             message: err.message,
             error: err

--- a/public/js/moe_result.js
+++ b/public/js/moe_result.js
@@ -21,7 +21,8 @@
     },
 
     createLoading: function() {
-      Loader.$wrapImg.append('<div id="js-pixiv-loading-' + this.imgId + '" class="m-b-xxl"><img id="js-img-pixiv" class="img-pixiv-loading" src="/img/ahe/0.png" />');
+      console.log(Loader.$wrapImg.data('moegao'));
+      Loader.$wrapImg.append('<div id="js-pixiv-loading-' + this.imgId + '" class="m-b-xxl"><img id="js-img-pixiv" class="img-pixiv-loading" src="' + Loader.$wrapImg.data('moegao') + '"/>');
     },
 
     render: function() {
@@ -77,9 +78,8 @@
   function main() {
     var json = JSON.parse($('#js-json-pixivkeyword').html());
     var pixivKeyword = json.pixivKeyword;
-    // TODO(furukawa san): こんな感じでキーワードを配列でもらえると並列でfetchします
     // JSONはmoe_result.ejsに埋め込んであります
-    var pixivKeywords = ['ぴかちゅー', 'マリオ', 'アスナ' ];
+    var pixivKeywords = pixivKeyword; 
     var imageModel = new ImageModel();
     var imageModel = new ImageModel(pixivKeywords);
     imageModel.getAllImage();

--- a/public/js/moe_result.js
+++ b/public/js/moe_result.js
@@ -3,56 +3,87 @@
 
   // pixiv画像のローダー
   var Loader = function (data) {
-    this.$imgElm = $('#js-img-pixiv');
-    this.$textLoading = $('#js-text-pixiv-loading');
-    this.$wrapImg = $('#js-wrap-img');
     this.imgUrl = data.pixivImage;
     this.pixivUrl = data.pixivUrl;
+    this.imgId = Loader.imgId;
+    Loader.imgId++;
   };
+
+  Loader.imgId = 0;
+  Loader.$wrapImg = $('#js-wrap-img');
 
   Loader.prototype = {
     load: function() {
-      // なかったら
-      if (!this.imgUrl) {
-        this.render();
-        return;
-      }
+      this.createLoading();
       var img = new Image();
       $(img).one('load', this.render.bind(this));
       img.src = this.imgUrl;
     },
 
+    createLoading: function() {
+      Loader.$wrapImg.append('<div id="js-pixiv-loading-' + this.imgId + '" class="m-b-xxl"><img id="js-img-pixiv" class="img-pixiv-loading" src="/img/ahe/0.png" />');
+    },
+
     render: function() {
-      var html = '<p>見つかりませんでした。</p>';
-      if (this.imgUrl) {
-        html = '<a href="' + this.pixivUrl + '" target="_blank"><img id="js-img-pixiv" class="img-pixiv" src="' + this.imgUrl + '" /></a>';
-      }
       // 雑ｗ
-      this.$wrapImg.html(html);
+      $('#js-pixiv-loading-' + this.imgId).remove();
+      var html = '<div><a href="' + this.pixivUrl + '" target="_blank"><img id="js-img-pixiv" class="img-pixiv" src="' + this.imgUrl + '" /></a></div>';
+      Loader.$wrapImg.append($(html));
+    }
+  };
+
+  var ImageModel = function(keywords) {
+    this.keywords = keywords;
+    this.foundImageNum = 0;
+    this.calledApiNum = 0;
+  };
+
+  ImageModel.prototype = {
+    getAllImage: function() {
+      for (var i = 0, l = this.keywords.length; i < l; i++) {
+        this.get(this.keywords[i]);
+      }
+    },
+
+    get: function(pixivKeyword) {
+      var that = this;
+      $.ajax({
+        type:        'get',
+        url:         '/pixiv',
+        data:        {pixivKeyword: pixivKeyword},
+        contentType: 'application/json',
+        dataType:    'json',
+        success: function(data) {
+          that.calledApiNum++;
+
+          if (data.pixivUrl != '') {
+            that.foundImageNum++;
+            var loader = new Loader(data);
+            loader.load();
+          }
+
+          if (that.foundImageNum === 0 &&
+            that.calledApiNum === that.keywords.length) {
+            $('#js-wrap-img').html('<p>見つかりませんでした。</p>');
+          }
+        },
+        error: function() {
+          alert('エラーｗｗ');
+        }
+      });
     }
   }
 
   function main() {
     var json = JSON.parse($('#js-json-pixivkeyword').html());
     var pixivKeyword = json.pixivKeyword;
-
-    $.ajax({
-      type:        'get',
-      url:         '/pixiv',
-      data:        {pixivKeyword: pixivKeyword},
-      contentType: 'application/json',
-      dataType:    'json',
-      success: function(data) {
-        var loader = new Loader(data);
-        loader.load();
-      },
-      error: function() {
-        alert('エラーｗｗ');
-      }
-    });
-
+    // TODO(furukawa san): こんな感じでキーワードを配列でもらえると並列でfetchします
+    // JSONはmoe_result.ejsに埋め込んであります
+    var pixivKeywords = ['ぴかちゅー', 'マリオ', 'アスナ' ];
+    var imageModel = new ImageModel();
+    var imageModel = new ImageModel(pixivKeywords);
+    imageModel.getAllImage();
   }
-
 
   $(window).on('load', main);
 

--- a/routes/moeResult.js
+++ b/routes/moeResult.js
@@ -14,6 +14,8 @@ var moeMessages = [
   "その性癖には流石に引いてます",
 ];
 
+var IMG_NUM = 3;
+
 var getAoriText = function(moerate){
   var moeLen = moeMessages.length;
   for (var i=0; i<moeLen; i++) {
@@ -68,12 +70,16 @@ router.get('/:result/*', function(req, res) {
       }
       var aori = "なんか選べよ！！！";
       var pixivKeyword = "";
+      var moegao = _.sample([0, 1, 2, 3]);
 
       if (data.result.length !== 0) {
         moerate = moerate / data.result.length;
         aori = getAoriText(moerate);
         moerate = parseInt(moerate * 100);
-        pixivKeyword = _.sample(data.result).entryName;
+        pixivKeyword = _.sample(data.result, IMG_NUM).map(function(entry){
+          return entry.entryName;
+        });
+        console.log("test", pixivKeyword);
       }
 
       var url = "http://oremoe.herokuapp.com/moe_result/" + req.params.result + "/"; 
@@ -81,6 +87,7 @@ router.get('/:result/*', function(req, res) {
         res.render('moe_result', {
           names: names || "何も選んでない...",
           moerate: moerate,
+          moegao: moegao,
           url: url,
           namesStr: namesStr || "何も選んでない...",
           seoWordsForUrl: seoWordsForUrl || "",

--- a/routes/pixiv.js
+++ b/routes/pixiv.js
@@ -6,9 +6,10 @@ var _ = require('lodash');
 
 router.get('/', function(req, res) {
   var pixivKeyword = req.query.pixivKeyword || "";
+  console.log(pixivKeyword);
   var orderBy = _.sample(["date", ""]);
   pixiv.search({
-    word: pixivKeyword,
+    word: pixivKeyword + " AND (100 OR なにこれ OR クリック推奨)",
     order: orderBy,
   }, function(images){
     var pixivImage = "";
@@ -22,7 +23,7 @@ router.get('/', function(req, res) {
     }
     res.status(200).json({  
       pixivImage: pixivImage,
-      pixivUrl: pixivUrl
+      pixivUrl: pixivUrl,
     });
   });
 });

--- a/views/moe_result.ejs
+++ b/views/moe_result.ejs
@@ -40,11 +40,7 @@
 
       <section class="sec-pixiv-image m-b-xl">
         <h1 class="title-type1 m-b-l">あなたの好みの画像は...</h1>
-        <div id="js-wrap-img" class="wrap-img">
-            
-            <img id="js-img-pixiv" class="img-pixiv-loading" src="/img/ahe/0.png" />
-            <div id="js-text-pixiv-loading" class="text-pixiv-loading">読み込み中</div>
-        </div>
+        <div id="js-wrap-img" class="wrap-img"></div>
       </section>
 
       <section class="sec-graph">

--- a/views/moe_result.ejs
+++ b/views/moe_result.ejs
@@ -39,8 +39,8 @@
       </section>
 
       <section class="sec-pixiv-image m-b-xl">
-        <h1 class="title-type1 m-b-l">あなたの好みの画像は...</h1>
-        <div id="js-wrap-img" class="wrap-img"></div>
+        <h1 class="title-type1 m-b-l">あなたの今夜のおかずは...</h1>
+        <div id="js-wrap-img" class="wrap-img" data-moegao="/img/ahe/<%=moegao%>.png"></div>
       </section>
 
       <section class="sec-graph">
@@ -64,6 +64,7 @@
 
       <% include include/footer %>
     </div>
+
     <script id="js-json-pixivkeyword" type="text/json"><%- JSON.stringify(pixivKeyword) %></script>
     <% include include/script %>
     <script src="/js/moe_result.js"></script>


### PR DESCRIPTION
@yosuke-furukawa 

並列でピクシブ画像をフェッチできるようにしました。
['要素1', '要素2','要素3']みたいな形のjsonをmoe_result.ejsに埋め込んでもらうと実行されます。
